### PR TITLE
Stop ztempfile's cleanup code from return an exit code of 1 if the file has already been removed

### DIFF
--- a/scripts/zoptparse.sh
+++ b/scripts/zoptparse.sh
@@ -96,7 +96,7 @@ function ztempfile()
     local tmpfile=$(mktemp -q --tmpdir="$prefix" "${label}.XXXXXXXXXX")
     eval "$1=$tmpfile"
     if [ -z "${_zdebug}" ]; then
-        eval " _zonexit+=( \"[ -f '$tmpfile' ] && rm -f '$tmpfile'\" ) "
+        eval " _zonexit+=( \"[ -f '$tmpfile' ] && rm -f '$tmpfile' || true\" ) "
     else
         zmessage "$tmpfile" # leave file around
     fi


### PR DESCRIPTION
If the user cleans up their ztempfile manually then the _zcleaner code inserted for a ztempfile
will fail on the file exists check and hence cause the script that included zoptparse.sh to
return an exit code of '1' unexpectedly (and without a warning :)

eg before the patch, the following code causes the script to exit with code 1:
`#!/usr/bin/bash

source "./zoptparse.sh"

zoptparse

ztempfile xxxx
rm -f $xxxx
exit 0
`

This change makes ztempfile consistent with the behaviour of ztempdir